### PR TITLE
Remove client cert settings and adjust clustertech error handling

### DIFF
--- a/app/assets/javascripts/amiko.eprescriptions.ts
+++ b/app/assets/javascripts/amiko.eprescriptions.ts
@@ -272,12 +272,13 @@ export async function importFromString(data: string) {
     const shouldSend = confirm(PrescriptionLocalization.send_to_zurrose + '?');
     if (shouldSend) {
         const zp = await ZurRosePrescription.fromEPrescription(ep);
-        try {
-            await zp.send();
+        // Not awaiting this, as it might take a long time before timeout
+        zp.send().then(()=> {
             alert(PrescriptionLocalization.prescription_is_sent_to_zurrose);
-        } catch (e) {
+        })
+        .catch(e => {
             alert(PrescriptionLocalization.error + ': ' + e);
-        }
+        });
     }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -201,11 +201,13 @@ play.ws {
     #}
     keyManager = {
       stores = [
-          {
-            type: "pkcs12",
-            path: "client.p12",
-            password: ""
-          },
+          # You can specific certificate via command line as well:
+          # -Dplay.ws.ssl.keyManager.stores.0.path=client.p12 -Dplay.ws.ssl.keyManager.stores.0.password=xxxx -Dplay.ws.ssl.keyManager.stores.0.type=pkcs12
+          # {
+          #   type: "pkcs12",
+          #   path: "",
+          #   password: ""
+          # },
         ]
     }
   }


### PR DESCRIPTION
#117 

Sie können Zertifikat mit Command line setzen:

```
-Dplay.ws.ssl.keyManager.stores.0.path=/path/to/client.p12 -Dplay.ws.ssl.keyManager.stores.0.password=XXXXXXX -Dplay.ws.ssl.keyManager.stores.0.type=pkcs12
```